### PR TITLE
Feature/scalers

### DIFF
--- a/JAICore/jaicore-ml/src/main/java/jaicore/ml/dyadranking/util/AbstractDyadScaler.java
+++ b/JAICore/jaicore-ml/src/main/java/jaicore/ml/dyadranking/util/AbstractDyadScaler.java
@@ -6,10 +6,13 @@ import java.util.List;
 
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 
+import de.upb.isys.linearalgebra.Vector;
 import jaicore.ml.core.dataset.IInstance;
 import jaicore.ml.dyadranking.Dyad;
 import jaicore.ml.dyadranking.dataset.DyadRankingDataset;
+import jaicore.ml.dyadranking.dataset.DyadRankingInstance;
 import jaicore.ml.dyadranking.dataset.IDyadRankingInstance;
+import jaicore.ml.dyadranking.dataset.SparseDyadRankingInstance;
 
 /**
  * A scaler that can be fit to a certain dataset and then be used to standardize
@@ -28,7 +31,7 @@ public abstract class AbstractDyadScaler implements Serializable {
 
 	protected SummaryStatistics[] statsX;
 	protected SummaryStatistics[] statsY;
-	
+
 	public SummaryStatistics[] getStatsX() {
 		return statsX;
 	}
@@ -106,23 +109,126 @@ public abstract class AbstractDyadScaler implements Serializable {
 	}
 
 	/**
-	 * Transforms only the instances of each dyad according to the mean and
-	 * standard deviation of the data the scaler has been fit to. The attributes
-	 * with indices contained in ignoredIndices are not transformed. {
+	 * Transforms only the instances of each dyad according to the mean and standard
+	 * deviation of the data the scaler has been fit to. The attributes with indices
+	 * contained in ignoredIndices are not transformed. {
 	 * 
-	 * @param dataset The dataset of which the alternatives are to be standardized.
-	 * @param ignoredIndices The {@link List} of indices that are been ignored by the scaler.
+	 * @param dataset        The dataset of which the alternatives are to be
+	 *                       standardized.
+	 * @param ignoredIndices The {@link List} of indices that are been ignored by
+	 *                       the scaler.
 	 */
-	public abstract void transformInstances(DyadRankingDataset dataset, List<Integer> ignoredIndices);
+	public abstract void transformInstances(Dyad dyad, List<Integer> ignoredIndices);
 
 	/**
 	 * Transforms only the alternatives of each dyad according to the mean and
 	 * standard deviation of the data the scaler has been fit to.
 	 * 
-	 * @param dataset The dataset of which the alternatives are to be standardized.
-	 * @param ignoredIndices The {@link List} of indices that are been ignored by the scaler.
+	 * @param dataset        The dataset of which the alternatives are to be
+	 *                       standardized.
+	 * @param ignoredIndices The {@link List} of indices that are been ignored by
+	 *                       the scaler.
 	 */
-	public abstract void transformAlternatives(DyadRankingDataset dataset, List<Integer> ignoredIndices);
+	public abstract void transformAlternatives(Dyad dyad, List<Integer> ignoredIndices);
+
+	/**
+	 * Transforms an instance feature vector.
+	 * 
+	 * @param Instance       vector to be transformed
+	 * @param ignoredIndices
+	 */
+	public abstract void transformInstaceVector(Vector vector, List<Integer> ignoredIndices);
+
+	/**
+	 * Transforms only the instances of each dyad in a
+	 * {@link SparseDyadRankingInstance} according to the mean and standard
+	 * deviation of the data the scaler has been fit to. The attributes with indices
+	 * contained in ignoredIndices are not transformed. {
+	 * 
+	 * @param dataset        The dataset of which the alternatives are to be
+	 *                       standardized.
+	 * @param ignoredIndices The {@link List} of indices that are been ignored by
+	 *                       the scaler.
+	 */
+	public void transformInstances(SparseDyadRankingInstance drInstance, List<Integer> ignoredIndices) {
+		transformInstaceVector(drInstance.getDyadAtPosition(0).getInstance(), ignoredIndices);
+	}
+
+	/**
+	 * Transforms only the instances of each dyad in a
+	 * {@link DyadRankingInstance} according to the mean and standard
+	 * deviation of the data the scaler has been fit to. The attributes with indices
+	 * contained in ignoredIndices are not transformed. {
+	 * 
+	 * @param dataset        The dataset of which the alternatives are to be
+	 *                       standardized.
+	 * @param ignoredIndices The {@link List} of indices that are been ignored by
+	 *                       the scaler.
+	 */
+	public void transformInstances(DyadRankingInstance drInstance, List<Integer> ignoredIndices) {
+		for (Dyad dyad : drInstance)
+			transformInstances(dyad, ignoredIndices);
+	}
+
+	/**
+	 * Transforms only the alternatives of each dyad in an
+	 * {@link IDyadRankingInstance} according to the mean and standard
+	 * deviation of the data the scaler has been fit to. The attributes with indices
+	 * contained in ignoredIndices are not transformed. {
+	 * 
+	 * @param dataset        The dataset of which the alternatives are to be
+	 *                       standardized.
+	 * @param ignoredIndices The {@link List} of indices that are been ignored by
+	 *                       the scaler.
+	 */
+	public void transformAlternatives(IDyadRankingInstance drInstance, List<Integer> ignoredIndices) {
+		for (Dyad dyad : drInstance)
+			transformAlternatives(dyad, ignoredIndices);
+	}
+
+	/**
+	 * Transforms only the instances of each dyad in a
+	 * {@link DyadRankingDataset} according to the mean and standard
+	 * deviation of the data the scaler has been fit to. The attributes with indices
+	 * contained in ignoredIndices are not transformed. {
+	 * 
+	 * @param dataset        The dataset of which the alternatives are to be
+	 *                       standardized.
+	 * @param ignoredIndices The {@link List} of indices that are been ignored by
+	 *                       the scaler.
+	 */
+	public void transformInstances(DyadRankingDataset dataset, List<Integer> ignoredIndices) {
+		for (IInstance instance : dataset) {
+			if (instance instanceof SparseDyadRankingInstance) {
+				SparseDyadRankingInstance drSparseInstance = (SparseDyadRankingInstance) instance;
+				this.transformInstances(drSparseInstance, ignoredIndices);
+			} else if (instance instanceof DyadRankingInstance) {
+				DyadRankingInstance drDenseInstance = (DyadRankingInstance) instance;
+				this.transformInstances(drDenseInstance, ignoredIndices);
+			} else {
+				throw new IllegalArgumentException(
+						"The scalers only support SparseDyadRankingInstance and DyadRankingInstance!");
+			}
+		}
+	}
+
+	/**
+	 * Transforms only the alternatives of each dyad in a
+	 * {@link DyadRankingDataset} according to the mean and standard
+	 * deviation of the data the scaler has been fit to. The attributes with indices
+	 * contained in ignoredIndices are not transformed. {
+	 * 
+	 * @param dataset        The dataset of which the alternatives are to be
+	 *                       standardized.
+	 * @param ignoredIndices The {@link List} of indices that are been ignored by
+	 *                       the scaler.
+	 */
+	public void transformAlternatives(DyadRankingDataset dataset, List<Integer> ignoredIndices) {
+		for (IInstance instance : dataset) {
+			IDyadRankingInstance drInstance = (IDyadRankingInstance) instance;
+			this.transformAlternatives(drInstance, ignoredIndices);
+		}
+	}
 
 	/**
 	 * Fits the standard scaler to the dataset and transforms the entire dataset

--- a/JAICore/jaicore-ml/src/main/java/jaicore/ml/dyadranking/util/DyadMinMaxScaler.java
+++ b/JAICore/jaicore-ml/src/main/java/jaicore/ml/dyadranking/util/DyadMinMaxScaler.java
@@ -44,6 +44,8 @@ public class DyadMinMaxScaler extends AbstractDyadScaler {
 				for (int i = 0; i < lengthX; i++) {
 					double value = dyad.getInstance().getValue(i);
 					value -= statsX[i].getMin();
+					// prevent division by zero
+					if((statsX[i].getMax() - statsX[i].getMin()) != 0)
 					value /= statsX[i].getMax() - statsX[i].getMin();
 					dyad.getInstance().setValue(i, value);
 				}
@@ -68,6 +70,8 @@ public class DyadMinMaxScaler extends AbstractDyadScaler {
 					if (!ignoredIndices.contains(i)) {
 						double value = dyad.getAlternative().getValue(i);
 						value -= statsY[i].getMin();
+						// prevent division by zero						
+						if((statsY[i].getMax() - statsY[i].getMin()) != 0)
 						value /= statsY[i].getMax() - statsY[i].getMin();
 						dyad.getAlternative().setValue(i, value);
 					}

--- a/JAICore/jaicore-ml/src/main/java/jaicore/ml/dyadranking/util/DyadMinMaxScaler.java
+++ b/JAICore/jaicore-ml/src/main/java/jaicore/ml/dyadranking/util/DyadMinMaxScaler.java
@@ -4,11 +4,11 @@ import java.util.List;
 
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 
+import de.upb.isys.linearalgebra.Vector;
 import jaicore.ml.core.dataset.IInstance;
 import jaicore.ml.dyadranking.Dyad;
 import jaicore.ml.dyadranking.dataset.DyadRankingDataset;
 import jaicore.ml.dyadranking.dataset.IDyadRankingInstance;
-
 
 /**
  * A scaler that can be fit to a certain dataset and then be used to normalize
@@ -27,58 +27,6 @@ public class DyadMinMaxScaler extends AbstractDyadScaler {
 	 * 
 	 */
 	private static final long serialVersionUID = -1319262573945961139L;
-
-	/**
-	 * Transforms only the instances of each dyad according to the mean and standard
-	 * of the data the scaler has been fit to.
-	 * 
-	 * @param dataset
-	 *            The dataset of which the instances are to be standardized.
-	 */
-	@Override
-	public void transformInstances(DyadRankingDataset dataset, List<Integer> ignoredIndices) {
-		int lengthX = dataset.get(0).getDyadAtPosition(0).getInstance().length();
-		for (IInstance instance : dataset) {
-			IDyadRankingInstance drInstance = (IDyadRankingInstance) instance;
-			for (Dyad dyad : drInstance) {
-				for (int i = 0; i < lengthX; i++) {
-					double value = dyad.getInstance().getValue(i);
-					value -= statsX[i].getMin();
-					// prevent division by zero
-					if((statsX[i].getMax() - statsX[i].getMin()) != 0)
-					value /= statsX[i].getMax() - statsX[i].getMin();
-					dyad.getInstance().setValue(i, value);
-				}
-			}
-		}
-	}
-
-	/**
-	 * Transforms only the alternatives of each dyad according to the mean and
-	 * standard deviation of the data the scaler has been fit to.
-	 * 
-	 * @param dataset
-	 *            The dataset of which the alternatives are to be standardized.
-	 */
-	@Override
-	public void transformAlternatives(DyadRankingDataset dataset, List<Integer> ignoredIndices) {
-		int lengthY = dataset.get(0).getDyadAtPosition(0).getAlternative().length();
-		for (IInstance instance : dataset) {
-			IDyadRankingInstance drInstance = (IDyadRankingInstance) instance;
-			for (Dyad dyad : drInstance) {
-				for (int i = 0; i < lengthY; i++) {
-					if (!ignoredIndices.contains(i)) {
-						double value = dyad.getAlternative().getValue(i);
-						value -= statsY[i].getMin();
-						// prevent division by zero						
-						if((statsY[i].getMax() - statsY[i].getMin()) != 0)
-						value /= statsY[i].getMax() - statsY[i].getMin();
-						dyad.getAlternative().setValue(i, value);
-					}
-				}
-			}
-		}
-	}
 
 	public void untransform(DyadRankingDataset dataset) {
 		int lengthX = dataset.get(0).getDyadAtPosition(0).getInstance().length();
@@ -193,6 +141,44 @@ public class DyadMinMaxScaler extends AbstractDyadScaler {
 			System.out.print(stats.getMin() + ", ");
 		}
 		System.out.println();
+	}
+
+	@Override
+	public void transformInstances(Dyad dyad, List<Integer> ignoredIndices) {
+		for (int i = 0; i < dyad.getInstance().length(); i++) {
+			double value = dyad.getInstance().getValue(i);
+			value -= statsX[i].getMin();
+			// prevent division by zero
+			if ((statsX[i].getMax() - statsX[i].getMin()) != 0)
+				value /= statsX[i].getMax() - statsX[i].getMin();
+			dyad.getInstance().setValue(i, value);
+		}
+	}
+
+	@Override
+	public void transformAlternatives(Dyad dyad, List<Integer> ignoredIndices) {
+		for (int i = 0; i < dyad.getAlternative().length(); i++) {
+			if (!ignoredIndices.contains(i)) {
+				double value = dyad.getAlternative().getValue(i);
+				value -= statsY[i].getMin();
+				// prevent division by zero
+				if ((statsY[i].getMax() - statsY[i].getMin()) != 0)
+					value /= statsY[i].getMax() - statsY[i].getMin();
+				dyad.getAlternative().setValue(i, value);
+			}
+		}
+	}
+
+	@Override
+	public void transformInstaceVector(Vector vector, List<Integer> ignoredIndices) {
+		for (int i = 0; i < vector.length(); i++) {
+			double value = vector.getValue(i);
+			value -= statsX[i].getMin();
+			// prevent division by zero
+			if ((statsX[i].getMax() - statsX[i].getMin()) != 0)
+				value /= statsX[i].getMax() - statsX[i].getMin();
+			vector.setValue(i, value);
+		}
 	}
 
 }

--- a/JAICore/jaicore-ml/src/main/java/jaicore/ml/dyadranking/util/DyadStandardScaler.java
+++ b/JAICore/jaicore-ml/src/main/java/jaicore/ml/dyadranking/util/DyadStandardScaler.java
@@ -2,6 +2,7 @@ package jaicore.ml.dyadranking.util;
 
 import java.util.List;
 
+import de.upb.isys.linearalgebra.Vector;
 import jaicore.ml.core.dataset.IInstance;
 import jaicore.ml.dyadranking.Dyad;
 import jaicore.ml.dyadranking.dataset.DyadRankingDataset;
@@ -22,47 +23,41 @@ public class DyadStandardScaler extends AbstractDyadScaler {
 	 */
 	private static final long serialVersionUID = 1L;
 
-	/**
-	 * Transforms only the instances of each dyad according to the mean and standard
-	 * of the data the scaler has been fit to.
-	 * 
-	 * @param dataset
-	 *            The dataset of which the instances are to be standardized.
-	 */
 	@Override
-	public void transformInstances(DyadRankingDataset dataset, List<Integer> ignoredIndices) {
-		int lengthX = dataset.get(0).getDyadAtPosition(0).getInstance().length();
-		for (IInstance instance : dataset) {
-			IDyadRankingInstance drInstance = (IDyadRankingInstance) instance;
-			for (Dyad dyad : drInstance) {
-				for (int i = 0; i < lengthX; i++) {
-					if (!ignoredIndices.contains(i)) {
-						double value = dyad.getInstance().getValue(i);
-						value -= statsX[i].getMean();
-						if(statsX[i].getStandardDeviation() != 0)
-						value /= statsX[i].getStandardDeviation();
-						dyad.getInstance().setValue(i, value);
-					}
-				}
+	public void transformInstances(Dyad dyad, List<Integer> ignoredIndices) {
+		for (int i = 0; i < dyad.getInstance().length(); i++) {
+			if (!ignoredIndices.contains(i)) {
+				double value = dyad.getInstance().getValue(i);
+				value -= statsX[i].getMean();
+				if (statsX[i].getStandardDeviation() != 0)
+					value /= statsX[i].getStandardDeviation();
+				dyad.getInstance().setValue(i, value);
 			}
 		}
 	}
 
 	@Override
-	public void transformAlternatives(DyadRankingDataset dataset, List<Integer> ignoredIndices) {
-		int lengthY = dataset.get(0).getDyadAtPosition(0).getAlternative().length();
-		for (IInstance instance : dataset) {
-			IDyadRankingInstance drInstance = (IDyadRankingInstance) instance;
-			for (Dyad dyad : drInstance) {
-				for (int i = 0; i < lengthY; i++) {
-					if (!ignoredIndices.contains(i)) {
-						double value = dyad.getAlternative().getValue(i);
-						value -= statsY[i].getMean();
-						if(statsY[i].getStandardDeviation() != 0)
-						value /= statsY[i].getStandardDeviation();
-						dyad.getAlternative().setValue(i, value);
-					}
-				}
+	public void transformAlternatives(Dyad dyad, List<Integer> ignoredIndices) {
+		for (int i = 0; i < dyad.getAlternative().length(); i++) {
+			if (!ignoredIndices.contains(i)) {
+				double value = dyad.getAlternative().getValue(i);
+				value -= statsY[i].getMean();
+				if (statsY[i].getStandardDeviation() != 0)
+					value /= statsY[i].getStandardDeviation();
+				dyad.getAlternative().setValue(i, value);
+			}
+		}
+	}
+
+	@Override
+	public void transformInstaceVector(Vector vector, List<Integer> ignoredIndices) {
+		for (int i = 0; i < vector.length(); i++) {
+			if (!ignoredIndices.contains(i)) {
+				double value = vector.getValue(i);
+				value -= statsX[i].getMean();
+				if (statsX[i].getStandardDeviation() != 0)
+					value /= statsX[i].getStandardDeviation();
+				vector.setValue(i, value);
 			}
 		}
 	}

--- a/JAICore/jaicore-ml/src/main/java/jaicore/ml/dyadranking/util/DyadStandardScaler.java
+++ b/JAICore/jaicore-ml/src/main/java/jaicore/ml/dyadranking/util/DyadStandardScaler.java
@@ -39,6 +39,7 @@ public class DyadStandardScaler extends AbstractDyadScaler {
 					if (!ignoredIndices.contains(i)) {
 						double value = dyad.getInstance().getValue(i);
 						value -= statsX[i].getMean();
+						if(statsX[i].getStandardDeviation() != 0)
 						value /= statsX[i].getStandardDeviation();
 						dyad.getInstance().setValue(i, value);
 					}
@@ -57,6 +58,7 @@ public class DyadStandardScaler extends AbstractDyadScaler {
 					if (!ignoredIndices.contains(i)) {
 						double value = dyad.getAlternative().getValue(i);
 						value -= statsY[i].getMean();
+						if(statsY[i].getStandardDeviation() != 0)
 						value /= statsY[i].getStandardDeviation();
 						dyad.getAlternative().setValue(i, value);
 					}

--- a/JAICore/jaicore-ml/src/main/java/jaicore/ml/dyadranking/util/DyadUnitIntervalScaler.java
+++ b/JAICore/jaicore-ml/src/main/java/jaicore/ml/dyadranking/util/DyadUnitIntervalScaler.java
@@ -2,6 +2,7 @@ package jaicore.ml.dyadranking.util;
 
 import java.util.List;
 
+import de.upb.isys.linearalgebra.Vector;
 import jaicore.ml.core.dataset.IInstance;
 import jaicore.ml.dyadranking.Dyad;
 import jaicore.ml.dyadranking.dataset.DyadRankingDataset;
@@ -16,59 +17,42 @@ import jaicore.ml.dyadranking.dataset.IDyadRankingInstance;
  */
 public class DyadUnitIntervalScaler  extends AbstractDyadScaler {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = -6732663643697649308L;
 	
-	/**
-	 * Transforms only the instances of each dyad according to the mean and standard
-	 * of the data the scaler has been fit to.
-	 * 
-	 * @param dataset
-	 *            The dataset of which the instances are to be standardized.
-	 */
 	@Override
-	public void transformInstances(DyadRankingDataset dataset, List<Integer> ignoredIndices) {
-		int lengthX = dataset.get(0).getDyadAtPosition(0).getInstance().length();
-		for (IInstance instance : dataset) {
-			IDyadRankingInstance drInstance = (IDyadRankingInstance) instance;
-			for (Dyad dyad : drInstance) {
-				for (int i = 0; i < lengthX; i++) {
-					if (!ignoredIndices.contains(i)) {
-						double value = dyad.getInstance().getValue(i);
-						if (value != 0.0d)
-							value /= Math.sqrt(statsX[i].getSumsq());
-						dyad.getInstance().setValue(i, value);
-					}
-				}
+	public void transformInstances(Dyad dyad, List<Integer> ignoredIndices) {
+		for (int i = 0; i < dyad.getInstance().length(); i++) {
+			if (!ignoredIndices.contains(i)) {
+				double value = dyad.getInstance().getValue(i);
+				if (value != 0.0d)
+					value /= Math.sqrt(statsX[i].getSumsq());
+				dyad.getInstance().setValue(i, value);
 			}
 		}
 	}
 
-	/**
-	 * Transforms only the alternatives of each dyad according to the mean and
-	 * standard deviation of the data the scaler has been fit to.
-	 * 
-	 * @param dataset
-	 *            The dataset of which the alternatives are to be standardized.
-	 */
 	@Override
-	public void transformAlternatives(DyadRankingDataset dataset, List<Integer> ignoredIndices) {
-		int lengthY = dataset.get(0).getDyadAtPosition(0).getAlternative().length();
-		for (IInstance instance : dataset) {
-			IDyadRankingInstance drInstance = (IDyadRankingInstance) instance;
-			for (Dyad dyad : drInstance) {
-				for (int i = 0; i < lengthY; i++) {
-					if (!ignoredIndices.contains(i)) {
-						double value = dyad.getAlternative().getValue(i);
-						if (value != 0.0d)
-							value /= Math.sqrt(statsY[i].getSumsq());
-						dyad.getAlternative().setValue(i, value);
-					}
-				}
+	public void transformAlternatives(Dyad dyad, List<Integer> ignoredIndices) {
+		for (int i = 0; i < dyad.getAlternative().length(); i++) {
+			if (!ignoredIndices.contains(i)) {
+				double value = dyad.getAlternative().getValue(i);
+				if (value != 0.0d)
+					value /= Math.sqrt(statsY[i].getSumsq());
+				dyad.getAlternative().setValue(i, value);
 			}
-		}
+		}		
+	}
+
+	@Override
+	public void transformInstaceVector(Vector vector, List<Integer> ignoredIndices) {
+		for (int i = 0; i < vector.length(); i++) {
+			if (!ignoredIndices.contains(i)) {
+				double value = vector.getValue(i);
+				if (value != 0.0d)
+					value /= Math.sqrt(statsX[i].getSumsq());
+				vector.setValue(i, value);
+			}
+		}		
 	}
 
 }

--- a/JAICore/jaicore-ml/src/test/java/jaicore/ml/dyadranking/DyadScalerTest.java
+++ b/JAICore/jaicore-ml/src/test/java/jaicore/ml/dyadranking/DyadScalerTest.java
@@ -24,27 +24,33 @@ import jaicore.ml.dyadranking.util.DyadUnitIntervalScaler;
  */
 public class DyadScalerTest {
 
-	private double[] expectedStdResult;
+	private double[] expectedStdResultX;
 	
-	private double[] expectedUnitResult;
+	private double[] expectedUnitResultX;
 	
-	private double[] expectedMinMaxResult;
+	private double[] expectedMinMaxResultX;
+	
+	private double[] expectedStdResultY;
+	
+	private double[] expectedUnitResultY;
+	
+	private double[] expectedMinMaxResultY;
 
 
 	private DyadRankingDataset testingSet;
 
 	public void setupDataset() {
 		Vector instance = new DenseDoubleVector(new double[] { 1.0d});
-		Vector alternative = new DenseDoubleVector(new double[] { 1.0d});
+		Vector alternative = new DenseDoubleVector(new double[] { 4.0d});
 		Dyad dOne = new Dyad(instance, alternative);
 		instance = new DenseDoubleVector(new double[] {2.0d});
-		alternative = new DenseDoubleVector(new double[] {2.0d});
+		alternative = new DenseDoubleVector(new double[] {4.0d});
 		Dyad dTwo = new Dyad(instance, alternative);
 		instance = new DenseDoubleVector(new double[] {3.0d});
-		alternative = new DenseDoubleVector(new double[] {3.0d});
+		alternative = new DenseDoubleVector(new double[] {4.0d});
 		Dyad dThree = new Dyad(instance, alternative);
 		instance = new DenseDoubleVector(new double[] {10.0d});
-		alternative = new DenseDoubleVector(new double[] {10.0d});
+		alternative = new DenseDoubleVector(new double[] {4.0d});
 		Dyad dFour = new Dyad(instance, alternative);
 		DyadRankingInstance ranking = new DyadRankingInstance(Arrays.asList(dOne, dTwo, dThree, dFour));
 		List<IDyadRankingInstance> allRankings = Arrays.asList(ranking);
@@ -61,15 +67,21 @@ public class DyadScalerTest {
 		double stdTwo = (2.0 - mean) / stdDev;
 		double stdThree = (3.0 - mean) / stdDev;
 		double stdFour = (10.0 - mean) / stdDev;
-		expectedStdResult = new double[] { stdOne, stdTwo, stdThree, stdFour };
+		double stdAlt = 0.0d;
+		expectedStdResultX = new double[] { stdOne, stdTwo, stdThree, stdFour };
+		expectedStdResultY = new double[] { stdAlt, stdAlt, stdAlt, stdAlt };
+		
 		
 		// unit interval scaler
 		double lengthOfVector = Math.sqrt(1 + 4 + 9 + 100);
+		double lengthOfAltVector = Math.sqrt(16+16+16+16);
 		double unitOne = (1.0/ lengthOfVector);
 		double unitTwo =  (2.0/ lengthOfVector);
 		double unitThree =  (3.0/ lengthOfVector);
 		double unitFour =  (10.0/ lengthOfVector);
-		expectedUnitResult = new double [] {unitOne, unitTwo, unitThree, unitFour};
+		double unitAlt = (4.0 / lengthOfAltVector);
+		expectedUnitResultX = new double [] {unitOne, unitTwo, unitThree, unitFour};
+		expectedUnitResultY = new double[] { unitAlt, unitAlt, unitAlt, unitAlt };
 		
 		// min max scaler
 		double min = 1.0d;
@@ -80,7 +92,9 @@ public class DyadScalerTest {
 		double minmaxTwo =  (2.0d - min) / minmaxDiff;
 		double minmaxThree =  (3.0d - min) / minmaxDiff;
 		double minmaxFour =  (10.0d - min) / minmaxDiff;
-		expectedMinMaxResult = new double[] {minmaxOne, minmaxTwo, minmaxThree, minmaxFour};
+		double minmaxAlt = 0.0d;
+		expectedMinMaxResultX = new double[] {minmaxOne, minmaxTwo, minmaxThree, minmaxFour};
+		expectedMinMaxResultY = new double[] {minmaxAlt, minmaxAlt, minmaxAlt, minmaxAlt};
 	}
 
 	@Test
@@ -92,12 +106,12 @@ public class DyadScalerTest {
 		System.out.println("Testing transform instances...");
 		stdScaler.transformInstances(testingSet);
 		for (int i = 0; i < 4 ; i++) {
-			Assert.assertEquals(expectedStdResult[i], testingSet.get(0).getDyadAtPosition(i).getInstance().getValue(0), 0.0001);
+			Assert.assertEquals(expectedStdResultX[i], testingSet.get(0).getDyadAtPosition(i).getInstance().getValue(0), 0.0001);
 		}
 		System.out.println("Testing transform alternatives...");
 		stdScaler.transformAlternatives(testingSet);
 		for (int i = 0; i < 4 ; i++) {
-			Assert.assertEquals(expectedStdResult[i], testingSet.get(0).getDyadAtPosition(i).getAlternative().getValue(0), 0.0001);
+			Assert.assertEquals(expectedStdResultY[i], testingSet.get(0).getDyadAtPosition(i).getAlternative().getValue(0), 0.0001);
 		}
 	}
 
@@ -111,12 +125,12 @@ public class DyadScalerTest {
 		System.out.println("Testing transform instances...");
 		stdScaler.transformInstances(testingSet);
 		for (int i = 0; i < 4 ; i++) {
-			Assert.assertEquals(expectedUnitResult[i], testingSet.get(0).getDyadAtPosition(i).getInstance().getValue(0), 0.0001);
+			Assert.assertEquals(expectedUnitResultX[i], testingSet.get(0).getDyadAtPosition(i).getInstance().getValue(0), 0.0001);
 		}
 		System.out.println("Testing transform alternatives...");
 		stdScaler.transformAlternatives(testingSet);
 		for (int i = 0; i < 4 ; i++) {
-			Assert.assertEquals(expectedUnitResult[i], testingSet.get(0).getDyadAtPosition(i).getAlternative().getValue(0), 0.0001);
+			Assert.assertEquals(expectedUnitResultY[i], testingSet.get(0).getDyadAtPosition(i).getAlternative().getValue(0), 0.0001);
 		}
 	}
 	
@@ -129,12 +143,12 @@ public class DyadScalerTest {
 		System.out.println("Testing transform instances...");
 		stdScaler.transformInstances(testingSet);
 		for (int i = 0; i < 4 ; i++) {
-			Assert.assertEquals(expectedMinMaxResult[i], testingSet.get(0).getDyadAtPosition(i).getInstance().getValue(0), 0.0001);
+			Assert.assertEquals(expectedMinMaxResultX[i], testingSet.get(0).getDyadAtPosition(i).getInstance().getValue(0), 0.0001);
 		}
 		System.out.println("Testing transform alternatives...");
 		stdScaler.transformAlternatives(testingSet);
 		for (int i = 0; i < 4 ; i++) {
-			Assert.assertEquals(expectedMinMaxResult[i], testingSet.get(0).getDyadAtPosition(i).getAlternative().getValue(0), 0.0001);
+			Assert.assertEquals(expectedMinMaxResultY[i], testingSet.get(0).getDyadAtPosition(i).getAlternative().getValue(0), 0.0001);
 		}
 	}
 }

--- a/JAICore/jaicore-ml/src/test/java/jaicore/ml/dyadranking/DyadScalerTest.java
+++ b/JAICore/jaicore-ml/src/test/java/jaicore/ml/dyadranking/DyadScalerTest.java
@@ -19,38 +19,38 @@ import jaicore.ml.dyadranking.util.DyadUnitIntervalScaler;
 
 /**
  * Tests our basic scalers.
+ * 
  * @author Mirko Jürgens
  *
  */
 public class DyadScalerTest {
 
 	private double[] expectedStdResultX;
-	
-	private double[] expectedUnitResultX;
-	
-	private double[] expectedMinMaxResultX;
-	
-	private double[] expectedStdResultY;
-	
-	private double[] expectedUnitResultY;
-	
-	private double[] expectedMinMaxResultY;
 
+	private double[] expectedUnitResultX;
+
+	private double[] expectedMinMaxResultX;
+
+	private double[] expectedStdResultY;
+
+	private double[] expectedUnitResultY;
+
+	private double[] expectedMinMaxResultY;
 
 	private DyadRankingDataset testingSet;
 
 	public void setupDataset() {
-		Vector instance = new DenseDoubleVector(new double[] { 1.0d});
-		Vector alternative = new DenseDoubleVector(new double[] { 4.0d});
+		Vector instance = new DenseDoubleVector(new double[] { 1.0d });
+		Vector alternative = new DenseDoubleVector(new double[] { 4.0d });
 		Dyad dOne = new Dyad(instance, alternative);
-		instance = new DenseDoubleVector(new double[] {2.0d});
-		alternative = new DenseDoubleVector(new double[] {4.0d});
+		instance = new DenseDoubleVector(new double[] { 2.0d });
+		alternative = new DenseDoubleVector(new double[] { 4.0d });
 		Dyad dTwo = new Dyad(instance, alternative);
-		instance = new DenseDoubleVector(new double[] {3.0d});
-		alternative = new DenseDoubleVector(new double[] {4.0d});
+		instance = new DenseDoubleVector(new double[] { 3.0d });
+		alternative = new DenseDoubleVector(new double[] { 4.0d });
 		Dyad dThree = new Dyad(instance, alternative);
-		instance = new DenseDoubleVector(new double[] {10.0d});
-		alternative = new DenseDoubleVector(new double[] {4.0d});
+		instance = new DenseDoubleVector(new double[] { 10.0d });
+		alternative = new DenseDoubleVector(new double[] { 4.0d });
 		Dyad dFour = new Dyad(instance, alternative);
 		DyadRankingInstance ranking = new DyadRankingInstance(Arrays.asList(dOne, dTwo, dThree, dFour));
 		List<IDyadRankingInstance> allRankings = Arrays.asList(ranking);
@@ -60,7 +60,7 @@ public class DyadScalerTest {
 	@Before
 	public void setupExpectedResults() {
 		// standardization
-		//derived by wolfram alpha
+		// derived by wolfram alpha
 		double mean = 4.0;
 		double stdDev = 4.0825;
 		double stdOne = (1.0 - mean) / stdDev;
@@ -70,31 +70,30 @@ public class DyadScalerTest {
 		double stdAlt = 0.0d;
 		expectedStdResultX = new double[] { stdOne, stdTwo, stdThree, stdFour };
 		expectedStdResultY = new double[] { stdAlt, stdAlt, stdAlt, stdAlt };
-		
-		
+
 		// unit interval scaler
 		double lengthOfVector = Math.sqrt(1 + 4 + 9 + 100);
-		double lengthOfAltVector = Math.sqrt(16+16+16+16);
-		double unitOne = (1.0/ lengthOfVector);
-		double unitTwo =  (2.0/ lengthOfVector);
-		double unitThree =  (3.0/ lengthOfVector);
-		double unitFour =  (10.0/ lengthOfVector);
+		double lengthOfAltVector = Math.sqrt(16 + 16 + 16 + 16);
+		double unitOne = (1.0 / lengthOfVector);
+		double unitTwo = (2.0 / lengthOfVector);
+		double unitThree = (3.0 / lengthOfVector);
+		double unitFour = (10.0 / lengthOfVector);
 		double unitAlt = (4.0 / lengthOfAltVector);
-		expectedUnitResultX = new double [] {unitOne, unitTwo, unitThree, unitFour};
+		expectedUnitResultX = new double[] { unitOne, unitTwo, unitThree, unitFour };
 		expectedUnitResultY = new double[] { unitAlt, unitAlt, unitAlt, unitAlt };
-		
+
 		// min max scaler
 		double min = 1.0d;
 		double max = 10.0d;
 		double minmaxDiff = max - min;
-		//would be a division b 0
-		double minmaxOne = 	(1.0d - min)/ minmaxDiff;
-		double minmaxTwo =  (2.0d - min) / minmaxDiff;
-		double minmaxThree =  (3.0d - min) / minmaxDiff;
-		double minmaxFour =  (10.0d - min) / minmaxDiff;
+		// would be a division b 0
+		double minmaxOne = (1.0d - min) / minmaxDiff;
+		double minmaxTwo = (2.0d - min) / minmaxDiff;
+		double minmaxThree = (3.0d - min) / minmaxDiff;
+		double minmaxFour = (10.0d - min) / minmaxDiff;
 		double minmaxAlt = 0.0d;
-		expectedMinMaxResultX = new double[] {minmaxOne, minmaxTwo, minmaxThree, minmaxFour};
-		expectedMinMaxResultY = new double[] {minmaxAlt, minmaxAlt, minmaxAlt, minmaxAlt};
+		expectedMinMaxResultX = new double[] { minmaxOne, minmaxTwo, minmaxThree, minmaxFour };
+		expectedMinMaxResultY = new double[] { minmaxAlt, minmaxAlt, minmaxAlt, minmaxAlt };
 	}
 
 	@Test
@@ -105,17 +104,18 @@ public class DyadScalerTest {
 		stdScaler.fit(testingSet);
 		System.out.println("Testing transform instances...");
 		stdScaler.transformInstances(testingSet);
-		for (int i = 0; i < 4 ; i++) {
-			Assert.assertEquals(expectedStdResultX[i], testingSet.get(0).getDyadAtPosition(i).getInstance().getValue(0), 0.0001);
+		for (int i = 0; i < 4; i++) {
+			Assert.assertEquals(expectedStdResultX[i], testingSet.get(0).getDyadAtPosition(i).getInstance().getValue(0),
+					0.0001);
 		}
 		System.out.println("Testing transform alternatives...");
 		stdScaler.transformAlternatives(testingSet);
-		for (int i = 0; i < 4 ; i++) {
-			Assert.assertEquals(expectedStdResultY[i], testingSet.get(0).getDyadAtPosition(i).getAlternative().getValue(0), 0.0001);
+		for (int i = 0; i < 4; i++) {
+			Assert.assertEquals(expectedStdResultY[i],
+					testingSet.get(0).getDyadAtPosition(i).getAlternative().getValue(0), 0.0001);
 		}
 	}
 
-	
 	@Test
 	public void testUnitIntervalScaler() {
 		setupDataset();
@@ -124,16 +124,18 @@ public class DyadScalerTest {
 		stdScaler.fit(testingSet);
 		System.out.println("Testing transform instances...");
 		stdScaler.transformInstances(testingSet);
-		for (int i = 0; i < 4 ; i++) {
-			Assert.assertEquals(expectedUnitResultX[i], testingSet.get(0).getDyadAtPosition(i).getInstance().getValue(0), 0.0001);
+		for (int i = 0; i < 4; i++) {
+			Assert.assertEquals(expectedUnitResultX[i],
+					testingSet.get(0).getDyadAtPosition(i).getInstance().getValue(0), 0.0001);
 		}
 		System.out.println("Testing transform alternatives...");
 		stdScaler.transformAlternatives(testingSet);
-		for (int i = 0; i < 4 ; i++) {
-			Assert.assertEquals(expectedUnitResultY[i], testingSet.get(0).getDyadAtPosition(i).getAlternative().getValue(0), 0.0001);
+		for (int i = 0; i < 4; i++) {
+			Assert.assertEquals(expectedUnitResultY[i],
+					testingSet.get(0).getDyadAtPosition(i).getAlternative().getValue(0), 0.0001);
 		}
 	}
-	
+
 	@Test
 	public void testMinMaxScaler() {
 		setupDataset();
@@ -142,13 +144,15 @@ public class DyadScalerTest {
 		stdScaler.fit(testingSet);
 		System.out.println("Testing transform instances...");
 		stdScaler.transformInstances(testingSet);
-		for (int i = 0; i < 4 ; i++) {
-			Assert.assertEquals(expectedMinMaxResultX[i], testingSet.get(0).getDyadAtPosition(i).getInstance().getValue(0), 0.0001);
+		for (int i = 0; i < 4; i++) {
+			Assert.assertEquals(expectedMinMaxResultX[i],
+					testingSet.get(0).getDyadAtPosition(i).getInstance().getValue(0), 0.0001);
 		}
 		System.out.println("Testing transform alternatives...");
 		stdScaler.transformAlternatives(testingSet);
-		for (int i = 0; i < 4 ; i++) {
-			Assert.assertEquals(expectedMinMaxResultY[i], testingSet.get(0).getDyadAtPosition(i).getAlternative().getValue(0), 0.0001);
+		for (int i = 0; i < 4; i++) {
+			Assert.assertEquals(expectedMinMaxResultY[i],
+					testingSet.get(0).getDyadAtPosition(i).getAlternative().getValue(0), 0.0001);
 		}
 	}
 }


### PR DESCRIPTION
This pull request contains some refactoring of the dyad scalers. Specifically the concrete Scaler class now only implements the methods transformInstances(Dyad dyad, List<Integer> ignoredIndices), transformAlternatives(Dyad dyad, List<Integer> ignoredIndices) and transformInstaceVector(Vector vector, List<Integer> ignoredIndices). The last one is needed for SparseDyadRankingInstances. Methods for transforming entire IDyadRankingInstances or DyadRankingDatasets have been moved to the abstract super class. Additionally some division by zero bugs have been eliminated and a corresponding test case has been added to the DyadScalerTest.